### PR TITLE
Fix logging level key

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,7 +22,7 @@ spring.datasource.password=${kafkadb.password}
 spring.datasource.driver-class-name=org.postgresql.Driver
 
 logging.level.root=INFO
-logging.level.commit.demo.kafka=DEBUG
+logging.level.com.demo.kafka=DEBUG
 logging.file.name=logs/application.log
 logging.file.max-size=10MB
 logging.file.total-size-cap=50MB


### PR DESCRIPTION
## Summary
- fix the logger package name in `application.properties`

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fea44f2048333961b6cdccf1daa99